### PR TITLE
Refactor: patch-events to include attendees

### DIFF
--- a/__tests__/events.test.js
+++ b/__tests__/events.test.js
@@ -549,7 +549,8 @@ describe('PATCH /api/events/:_id', () => {
         { "user_name": "anakin" },
         { "user_name": "obi" },
         { "user_name": "quigon" }
-     ]
+     ],
+     max_attendees: 10
     }
     return request(app)
     .patch('/api/events/64c7b688411bcf756d6f0811')
@@ -566,6 +567,7 @@ describe('PATCH /api/events/:_id', () => {
          { "user_name": "obi" },
          { "user_name": "quigon" }
       ])
+      expect(updatedEvent.spaces_free).toBe(7)
     })
   }); 
   test('404: Should return an error when the id is non-existent', () => { 

--- a/__tests__/events.test.js
+++ b/__tests__/events.test.js
@@ -544,9 +544,13 @@ describe('PATCH /api/events/:_id', () => {
       event_name: "happy meal",
       event_date: "2023-08-01T00:00:00.000Z",
       event_description: "come get food",
-      event_duration: 3
+      event_duration: 3,
+      attendees: [
+        { "user_name": "anakin" },
+        { "user_name": "obi" },
+        { "user_name": "quigon" }
+     ]
     }
-
     return request(app)
     .patch('/api/events/64c7b688411bcf756d6f0811')
     .send(patchBody)
@@ -557,6 +561,11 @@ describe('PATCH /api/events/:_id', () => {
       expect(updatedEvent.event_date).toBe("2023-08-01T00:00:00.000Z")
       expect(updatedEvent.event_description).toBe( "come get food")
       expect(updatedEvent.event_duration).toBe(3)
+      expect(updatedEvent.attendees).toEqual([
+         { "user_name": "anakin"},
+         { "user_name": "obi" },
+         { "user_name": "quigon" }
+      ])
     })
   }); 
   test('404: Should return an error when the id is non-existent', () => { 
@@ -564,7 +573,12 @@ describe('PATCH /api/events/:_id', () => {
       event_name: "happy meal",
       event_date: "2023-08-01T00:00:00.000Z",
       event_description: "come get food",
-      event_duration: 3
+      event_duration: 3,
+      attendees: [
+        { "user_name": "anakin" },
+        { "user_name": "obi" },
+        { "user_name": "quigon" }
+     ]
     }
     return request(app)
     .patch('/api/events/64c7b688411bcf756d6f0899')
@@ -580,7 +594,12 @@ describe('PATCH /api/events/:_id', () => {
       event_name: "happy meal",
       event_date: "2023-08-01T00:00:00.000Z",
       event_description: "come get food",
-      event_duration: 3
+      event_duration: 3,
+      attendees: [
+        { "user_name": "anakin" },
+        { "user_name": "obi" },
+        { "user_name": "quigon" }
+     ]
     }
     return request(app)
     .patch('/api/events/64c7b688411bcf756d6f08?')
@@ -596,7 +615,12 @@ describe('PATCH /api/events/:_id', () => {
     event_name: '%',
     event_date: "2023-08-01T00:00:00.000Z",
     event_description: "come get food",
-    event_duration: 3
+    event_duration: 3,
+    attendees: [
+      { "user_name": "anakin" },
+      { "user_name": "obi" },
+      { "user_name": "quigon" }
+   ]
    }
    return request(app)
    .patch('/api/events/64c7b688411bcf756d6f0811')
@@ -612,7 +636,12 @@ describe('PATCH /api/events/:_id', () => {
      event_name: 'h',
      event_date: "2023-08-01T00:00:00.000Z%",
      event_description: "come get food",
-     event_duration: 3
+     event_duration: 3,
+     attendees: [
+      { "user_name": "anakin" },
+      { "user_name": "obi" },
+      { "user_name": "quigon" }
+   ]
     }
     return request(app)
     .patch('/api/events/64c7b688411bcf756d6f0811')
@@ -628,8 +657,34 @@ describe('PATCH /api/events/:_id', () => {
      event_name: 'h',
      event_date: "2023-08-01T00:00:00.000Z",
      event_description: "come get food",
-     event_duration: 'j'
+     event_duration: 'j',
+     attendees: [
+      { "user_name": "anakin" },
+      { "user_name": "obi" },
+      { "user_name": "quigon" }
+   ]
     }
+    return request(app)
+    .patch('/api/events/64c7b688411bcf756d6f0811')
+    .send(patchBody)
+    .expect(400)
+    .then(({body}) => {
+      expect(body).toHaveProperty("msg");
+      expect(body.msg).toBe("Bad Request");
+    })
+   });
+   test('400: Should return an error when request body has malformed value for attendees field', () => { 
+    const patchBody = {
+     event_name: 'h',
+     event_date: "2023-08-01T00:00:00.000Z",
+     event_description: "come get food",
+     event_duration: 2,
+     attendees: { 
+      "user_name": "anakin" ,
+       "user_name": "obi" ,
+      "user_name": "quigon"
+    }
+  }
     return request(app)
     .patch('/api/events/64c7b688411bcf756d6f0811')
     .send(patchBody)
@@ -641,6 +696,6 @@ describe('PATCH /api/events/:_id', () => {
    });
   });
 
-// non change patch
+
 
 

--- a/models/events-model.js
+++ b/models/events-model.js
@@ -191,7 +191,10 @@ if (patchBody.event_name) updateObj.event_name = patchBody.event_name;
 if (patchBody.event_date) updateObj.event_date = new Date(patchBody.event_date);
 if (patchBody.event_description) updateObj.event_description = patchBody.event_description;
 if (patchBody.event_duration) updateObj.event_duration = Number(patchBody.event_duration);
-if (patchBody.attendees) updateObj.attendees = patchBody.attendees;
+if (patchBody.attendees) {
+  updateObj.attendees = patchBody.attendees;
+  updateObj.spaces_free = patchBody.max_attendees - patchBody.attendees.length;
+}
 
 
   return connectToDatabase().then((client) => {

--- a/models/events-model.js
+++ b/models/events-model.js
@@ -190,7 +190,7 @@ exports.updateEvent = (_id, patchBody) => {
 if (patchBody.event_name) updateObj.event_name = patchBody.event_name;
 if (patchBody.event_date) updateObj.event_date = new Date(patchBody.event_date);
 if (patchBody.event_description) updateObj.event_description = patchBody.event_description;
-if (patchBody.event_duration) updateObj.event_duration = patchBody.event_duration;
+if (patchBody.event_duration) updateObj.event_duration = Number(patchBody.event_duration);
 if (patchBody.attendees) updateObj.attendees = patchBody.attendees;
 
 

--- a/models/events-model.js
+++ b/models/events-model.js
@@ -188,7 +188,7 @@ exports.updateEvent = (_id, patchBody) => {
   }
   const updateObj = {};
 if (patchBody.event_name) updateObj.event_name = patchBody.event_name;
-if (patchBody.event_date) updateObj.event_date = patchBody.event_date;
+if (patchBody.event_date) updateObj.event_date = new Date(patchBody.event_date);
 if (patchBody.event_description) updateObj.event_description = patchBody.event_description;
 if (patchBody.event_duration) updateObj.event_duration = patchBody.event_duration;
 if (patchBody.attendees) updateObj.attendees = patchBody.attendees;

--- a/models/events-model.js
+++ b/models/events-model.js
@@ -179,7 +179,7 @@ exports.updateEvent = (_id, patchBody) => {
   const dateRegex = /^[0-9A-Za-z\:.-]*$/;
  
 
-  if(!patchBody.event_name.match(letterRegex) || !patchBody.event_date.match(dateRegex) || isNaN(patchBody.event_duration)) {
+  if(!patchBody.event_name.match(letterRegex) || !patchBody.event_date.match(dateRegex) || isNaN(patchBody.event_duration) || !Array.isArray(patchBody.attendees)) {
     return Promise.reject({ status: 400, msg: "Bad Request" });
   }
 
@@ -191,6 +191,7 @@ if (patchBody.event_name) updateObj.event_name = patchBody.event_name;
 if (patchBody.event_date) updateObj.event_date = patchBody.event_date;
 if (patchBody.event_description) updateObj.event_description = patchBody.event_description;
 if (patchBody.event_duration) updateObj.event_duration = patchBody.event_duration;
+if (patchBody.attendees) updateObj.attendees = patchBody.attendees;
 
 
   return connectToDatabase().then((client) => {


### PR DESCRIPTION
I realised how wet it was going to be to have a separate endpoint for patching the attendees for the event, so I refactored the existing patch-event. 